### PR TITLE
fix/roscontrol boilerplate

### DIFF
--- a/.ci.rosinstall.kinetic
+++ b/.ci.rosinstall.kinetic
@@ -1,4 +1,0 @@
-- git:
-    local-name: ros_control_boilerplate
-    uri: https://github.com/mojin-robotics/ros_control_boilerplate.git
-    version: kinetic-devel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { ROS_DISTRO: kinetic, UPSTREAM_WORKSPACE: .ci.rosinstall.kinetic }
+          - { ROS_DISTRO: kinetic }
           - { ROS_DISTRO: noetic }
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - PYLINT_CHECK=true
     - ROS_REPO=main
   matrix:
-    - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=.ci.rosinstall.kinetic
+    - ROS_DISTRO=kinetic
     - ROS_DISTRO=noetic
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Status: [![Build Status](https://travis-ci.com/mojin-robotics/precise_ros.svg?br
 
 ## GitHub Actions - Continuous Integration
 
-CI-Status ```kinetic-devel```: [![Build Status](https://github.com/mojin-robotics/precise_ros/workflows/CI/badge.svg?branch=kinetic-devel)](https://github.com/mojin-robotics/precise_ros/actions?query=workflow%3ACI+branch%3Akinetic-devel)
+CI-Status ```kinetic-devel```: [![Build Status](https://github.com/mojin-robotics/precise_ros/workflows/CI/badge.svg?branch=kinetic-devel)](https://github.com/mojin-robotics/precise_ros/actions/workflows/main.yml?query=branch%3Akinetic-devel)

--- a/precise_driver/src/precise_hw_node.cpp
+++ b/precise_driver/src/precise_hw_node.cpp
@@ -1,3 +1,4 @@
+#include <ros/common.h>
 #include <ros_control_boilerplate/generic_hw_control_loop.h>
 #include <precise_driver/precise_hw_interface.h>
 
@@ -12,8 +13,14 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<precise_driver::PreciseHWInterface> precise_hw_interface
-    (new precise_driver::PreciseHWInterface(nh));
+  #if ROS_VERSION_MINIMUM(1, 15, 0) // ros noetic is 1.15.x
+    std::shared_ptr<precise_driver::PreciseHWInterface> precise_hw_interface
+      (new precise_driver::PreciseHWInterface(nh));
+  #else
+    boost::shared_ptr<precise_driver::PreciseHWInterface> precise_hw_interface
+      (new precise_driver::PreciseHWInterface(nh));
+  #endif
+
   precise_hw_interface->init();
 
   // Start the control loop


### PR DESCRIPTION
following https://github.com/PickNikRobotics/ros_control_boilerplate/issues/30, `roscontrol_boilerplate` has been updated for both `kinetic` and `noetic`

https://discourse.ros.org/t/new-packages-for-kinetic-kame-2021-03-08/19346
https://discourse.ros.org/t/new-packages-for-noetic-2021-03-12/19430

this PR makes `precise_driver` dual-distro compatible without needing an overlay anymore
