### PR TITLE
[kevin integration] Add new service for gripped teachmode

### DIFF
--- a/precise_driver/CMakeLists.txt
+++ b/precise_driver/CMakeLists.txt
@@ -19,6 +19,7 @@ add_service_files(
   FILES
   Gripper.srv
   Plate.srv
+  SetFreeMode.srv
 )
 
 generate_messages(

--- a/precise_driver/include/precise_driver/device/device.h
+++ b/precise_driver/include/precise_driver/device/device.h
@@ -75,7 +75,7 @@ namespace precise_driver
         bool attach(const bool flag);
 
         //enable/disable zero gravity composition (teach mode)
-        bool freeMode(const bool enabled, const uint8_t axes);
+        bool freeMode(const bool enabled, const int axes);
 
         //check if manipulator is operational for commanding joint states
         bool operational();

--- a/precise_driver/include/precise_driver/device/device.h
+++ b/precise_driver/include/precise_driver/device/device.h
@@ -75,7 +75,7 @@ namespace precise_driver
         bool attach(const bool flag);
 
         //enable/disable zero gravity composition (teach mode)
-        bool freeMode(const bool enabled);
+        bool freeMode(const bool enabled, const int axes);
 
         //check if manipulator is operational for commanding joint states
         bool operational();

--- a/precise_driver/include/precise_driver/device/device.h
+++ b/precise_driver/include/precise_driver/device/device.h
@@ -75,7 +75,7 @@ namespace precise_driver
         bool attach(const bool flag);
 
         //enable/disable zero gravity composition (teach mode)
-        bool freeMode(const bool enabled, const int axes);
+        bool freeMode(const bool enabled, const uint8_t axes);
 
         //check if manipulator is operational for commanding joint states
         bool operational();

--- a/precise_driver/include/precise_driver/precise_hw_interface.h
+++ b/precise_driver/include/precise_driver/precise_hw_interface.h
@@ -35,6 +35,7 @@ namespace precise_driver
         ros::ServiceServer init_srv_;
         ros::ServiceServer recover_srv_;
         ros::ServiceServer teachmode_srv_;
+        ros::ServiceServer teachmode_gripped_srv_;
         ros::ServiceServer home_srv_;
         ros::ServiceServer power_srv_;
         ros::ServiceServer attach_srv_;
@@ -63,6 +64,7 @@ namespace precise_driver
         bool initCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
         bool recoverCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
         bool teachmodeCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
+        bool teachmodeGrippedCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
         bool homeCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
         bool powerCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
         bool attachCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);

--- a/precise_driver/include/precise_driver/precise_hw_interface.h
+++ b/precise_driver/include/precise_driver/precise_hw_interface.h
@@ -36,7 +36,6 @@ namespace precise_driver
         ros::ServiceServer init_srv_;
         ros::ServiceServer recover_srv_;
         ros::ServiceServer teachmode_srv_;
-        ros::ServiceServer teachmode_gripped_srv_;
         ros::ServiceServer home_srv_;
         ros::ServiceServer power_srv_;
         ros::ServiceServer attach_srv_;

--- a/precise_driver/include/precise_driver/precise_hw_interface.h
+++ b/precise_driver/include/precise_driver/precise_hw_interface.h
@@ -6,6 +6,7 @@
 #include <precise_driver/device/tcp_client.h>
 #include <precise_driver/Gripper.h>
 #include <precise_driver/Plate.h>
+#include <precise_driver/SetFreeMode.h>
 #include <ros/ros.h>
 
 #include <mutex>
@@ -63,8 +64,7 @@ namespace precise_driver
 
         bool initCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
         bool recoverCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
-        bool teachmodeCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
-        bool teachmodeGrippedCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
+        bool teachmodeCb(precise_driver::SetFreeMode::Request &req, precise_driver::SetFreeMode::Response &res);
         bool homeCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
         bool powerCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
         bool attachCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);

--- a/precise_driver/src/device/device.cpp
+++ b/precise_driver/src/device/device.cpp
@@ -231,7 +231,7 @@ namespace precise_driver
     //   All axes free:                11111 = 31
     //   All axes except z-Axis free:  11110 = 30
     //   All axes except gripper free: 01111 = 15
-    bool Device::freeMode(const bool enabled, const int axes)
+    bool Device::freeMode(const bool enabled, const uint8_t axes)
     {
         std::stringstream ss;
         if(enabled)

--- a/precise_driver/src/device/device.cpp
+++ b/precise_driver/src/device/device.cpp
@@ -227,11 +227,15 @@ namespace precise_driver
     }
 
     //TODO: There is a freeMode command described the TCS Documentation
-    bool Device::freeMode(const bool enabled)
+    // axes is interpreted as bitmask:
+    //   All axes free:                11111 = 31
+    //   All axes except z-Axis free:  11110 = 30
+    //   All axes except gripper free: 01111 = 15
+  bool Device::freeMode(const bool enabled, const int axes)
     {
         std::stringstream ss;
         if(enabled)
-            ss << "zeroTorque " << static_cast<int>(enabled)<<" 31"; //bitmask 1=axis1, 2=axis2, 4=axis3 ...
+            ss << "zeroTorque " << static_cast<int>(enabled) << " " << axes;
         else
             ss << "zeroTorque " << static_cast<int>(enabled);
 

--- a/precise_driver/src/device/device.cpp
+++ b/precise_driver/src/device/device.cpp
@@ -231,7 +231,7 @@ namespace precise_driver
     //   All axes free:                11111 = 31
     //   All axes except z-Axis free:  11110 = 30
     //   All axes except gripper free: 01111 = 15
-    bool Device::freeMode(const bool enabled, const uint8_t axes)
+    bool Device::freeMode(const bool enabled, const int axes)
     {
         std::stringstream ss;
         if(enabled)

--- a/precise_driver/src/device/device.cpp
+++ b/precise_driver/src/device/device.cpp
@@ -231,7 +231,7 @@ namespace precise_driver
     //   All axes free:                11111 = 31
     //   All axes except z-Axis free:  11110 = 30
     //   All axes except gripper free: 01111 = 15
-  bool Device::freeMode(const bool enabled, const int axes)
+    bool Device::freeMode(const bool enabled, const int axes)
     {
         std::stringstream ss;
         if(enabled)

--- a/precise_driver/src/precise_hw_interface.cpp
+++ b/precise_driver/src/precise_hw_interface.cpp
@@ -141,7 +141,7 @@ namespace precise_driver
     bool PreciseHWInterface::teachmodeCb(precise_driver::SetFreeMode::Request &req, precise_driver::SetFreeMode::Response &res)
     {
         // Check bitmask size
-        if (req.axes > 31)
+        if (req.data && req.axes > 31)
         {
             res.success = false;
             res.message = "axes is interpreted as bitmask and must be in [0, 31]";

--- a/precise_driver/src/precise_hw_interface.cpp
+++ b/precise_driver/src/precise_hw_interface.cpp
@@ -32,7 +32,6 @@ namespace precise_driver
         init_srv_ = driver_nh.advertiseService("init", &PreciseHWInterface::initCb, this);
         recover_srv_ = driver_nh.advertiseService("recover", &PreciseHWInterface::recoverCb, this);
         teachmode_srv_ = driver_nh.advertiseService("teach_mode", &PreciseHWInterface::teachmodeCb, this);
-
         home_srv_ = driver_nh.advertiseService("home", &PreciseHWInterface::homeCb, this);
         power_srv_ = driver_nh.advertiseService("power", &PreciseHWInterface::powerCb, this);
         cmd_srv_ = driver_nh.advertiseService("command", &PreciseHWInterface::cmdCb, this);

--- a/precise_driver/src/precise_hw_interface.cpp
+++ b/precise_driver/src/precise_hw_interface.cpp
@@ -32,6 +32,7 @@ namespace precise_driver
         init_srv_ = driver_nh.advertiseService("init", &PreciseHWInterface::initCb, this);
         recover_srv_ = driver_nh.advertiseService("recover", &PreciseHWInterface::recoverCb, this);
         teachmode_srv_ = driver_nh.advertiseService("teach_mode", &PreciseHWInterface::teachmodeCb, this);
+        teachmode_gripped_srv_ = driver_nh.advertiseService("teach_mode_gripped", &PreciseHWInterface::teachmodeGrippedCb, this);
         home_srv_ = driver_nh.advertiseService("home", &PreciseHWInterface::homeCb, this);
         power_srv_ = driver_nh.advertiseService("power", &PreciseHWInterface::powerCb, this);
         cmd_srv_ = driver_nh.advertiseService("command", &PreciseHWInterface::cmdCb, this);
@@ -144,11 +145,11 @@ namespace precise_driver
 
         if(req.data)
         {
-            res.success = resetController(false) && device_->freeMode(req.data);
+            res.success = resetController(false) && device_->freeMode(req.data, 31);
         }
         else
         {
-            res.success = resetController(true) && device_->freeMode(req.data);
+            res.success = resetController(true) && device_->freeMode(req.data, 31);
         }
 
         enableWrite(true);
@@ -156,6 +157,24 @@ namespace precise_driver
         return true;
     }
 
+    bool PreciseHWInterface::teachmodeGrippedCb(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res)
+    {
+        enableWrite(false);
+
+        if(req.data)
+        {
+            res.success = resetController(false) && device_->freeMode(req.data, 15);
+        }
+        else
+        {
+            res.success = resetController(true) && device_->freeMode(req.data, 15);
+        }
+
+        enableWrite(true);
+
+        return true;
+    }
+  
     bool PreciseHWInterface::homeCb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
     {
         enableWrite(false);

--- a/precise_driver/srv/SetFreeMode.srv
+++ b/precise_driver/srv/SetFreeMode.srv
@@ -1,0 +1,5 @@
+bool data
+uint8 axes
+---
+bool success
+string message


### PR DESCRIPTION
This feature adds a new service `teach_mode_gripped` analogously to the existing `teach_mode` service.
The difference is that all axes except the gripper are set force free, which is useful for teaching new positions when the teaching plate is already gripped.