### PR TITLE
fix xacro.load_yaml deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { ROS_DISTRO: kinetic }
+          # - { ROS_DISTRO: kinetic }
           - { ROS_DISTRO: noetic }
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - PYLINT_CHECK=true
     - ROS_REPO=main
   matrix:
-    - ROS_DISTRO=kinetic
+    # - ROS_DISTRO=kinetic
     - ROS_DISTRO=noetic
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master

--- a/precise_description/robots/PF400_long.urdf.xacro
+++ b/precise_description/robots/PF400_long.urdf.xacro
@@ -3,7 +3,7 @@
        name="PF400_long">
 
   <xacro:property name="yaml_file" value="$(find precise_description)/robots/PF400_long.yaml"/>
-  <xacro:property name="robot_properties" value="${load_yaml(yaml_file)}"/>
+  <xacro:property name="robot_properties" value="${xacro.load_yaml(yaml_file)}"/>
 
   <xacro:include filename="$(find precise_description)/urdf/precise_flex.urdf.xacro"/>
 

--- a/precise_description/robots/PF400_short.urdf.xacro
+++ b/precise_description/robots/PF400_short.urdf.xacro
@@ -3,7 +3,7 @@
        name="PF400_short">
 
   <xacro:property name="yaml_file" value="$(find precise_description)/robots/PF400_short.yaml"/>
-  <xacro:property name="robot_properties" value="${load_yaml(yaml_file)}"/>
+  <xacro:property name="robot_properties" value="${xacro.load_yaml(yaml_file)}"/>
 
   <xacro:include filename="$(find precise_description)/urdf/precise_flex.urdf.xacro"/>
 


### PR DESCRIPTION
```
Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
```