### PR TITLE
Set diagnostics state to OK in teachmode

### DIFF
--- a/precise_driver/include/precise_driver/device/device.h
+++ b/precise_driver/include/precise_driver/device/device.h
@@ -81,6 +81,8 @@ namespace precise_driver
         bool is_operational();
         //check if manipulator has completed init routine
         bool is_init();
+        //check if manipulator is in teach mode
+        bool is_teachmode();
         //fill some internal info for diagnostics
         void fill_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
 

--- a/precise_driver/src/device/device.cpp
+++ b/precise_driver/src/device/device.cpp
@@ -270,6 +270,16 @@ namespace precise_driver
         return ret;
     }
 
+    bool Device::is_teachmode()
+    {
+        bool ret;
+        {
+            std::lock_guard<std::mutex> guard(mutex_state_data_);
+            ret = is_teachmode_;
+        }
+        return ret;
+    }
+
     void Device::fill_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat)
     {
         {

--- a/precise_driver/src/precise_hw_interface.cpp
+++ b/precise_driver/src/precise_hw_interface.cpp
@@ -419,7 +419,7 @@ namespace precise_driver
 
     void PreciseHWInterface::produce_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat)
     {
-        if(device_->is_operational())
+        if(device_->is_operational() || device_->is_teachmode())
         {
             stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Driver operational");
         }


### PR DESCRIPTION
The diagnostics switch to `ERROR` when in teachmode. Since this is a valid arm state they should be in `OK`.